### PR TITLE
fix: update domains and module paths

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -3,14 +3,14 @@
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
 cliVersion: 4.7.1
-domain: example.com
+domain: ecs.takutakahashi.dev
 layout:
 - go.kubebuilder.io/v4
 projectName: pod-controller
-repo: github.com/example/pod-controller
+repo: github.com/takutakahashi/k8s-ecstask
 resources:
 - controller: true
-  domain: example.com
+  domain: ecs.takutakahashi.dev
   group: controller
   kind: PodWatcher
   version: v1

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 KubebuilderとMutating Webhookを使用して実装したPod制御システムです。
 
 ## 概要
-このシステムは、Kubernetesクラスター内で`example.com/watch`ラベルを持つPodの作成を完全にブロックします。MutatingWebhookを使用してPod作成時に介入し、特定ラベルを持つPodの作成を拒否します。
+このシステムは、Kubernetesクラスター内で`ecs.takutakahashi.dev/watch`ラベルを持つPodの作成を完全にブロックします。MutatingWebhookを使用してPod作成時に介入し、特定ラベルを持つPodの作成を拒否します。
 
 ### 主な機能
-- **Pod作成ブロック**: `example.com/watch`ラベルを持つPodの作成を完全に拒否
+- **Pod作成ブロック**: `ecs.takutakahashi.dev/watch`ラベルを持つPodの作成を完全に拒否
 - **選択的制御**: 特定ラベルを持たないPodは通常通り作成を許可
 - **ログ記録**: ブロックされたPodの情報をログに出力
 - **コントローラー監視**: Pod作成・削除イベントのログ記録

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,8 +37,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/example/pod-controller/internal/controller"
-	webhookv1 "github.com/example/pod-controller/internal/webhook/v1"
+	"github.com/takutakahashi/k8s-ecstask/internal/controller"
+	webhookv1 "github.com/takutakahashi/k8s-ecstask/internal/webhook/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -183,7 +183,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "a128a823.example.com",
+		LeaderElectionID:       "a128a823.ecs.takutakahashi.dev",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/examples/test-pod.yaml
+++ b/examples/test-pod.yaml
@@ -16,7 +16,7 @@ kind: Pod
 metadata:
   name: blocked-pod
   labels:
-    example.com/watch: "true"
+    ecs.takutakahashi.dev/watch: "true"
 spec:
   containers:
   - name: nginx

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/pod-controller
+module github.com/takutakahashi/k8s-ecstask
 
 go 1.24.0
 

--- a/internal/controller/podwatcher_controller.go
+++ b/internal/controller/podwatcher_controller.go
@@ -63,7 +63,7 @@ func (r *PodWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	labelPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if pod, ok := e.Object.(*corev1.Pod); ok {
-				if _, exists := pod.Labels["example.com/watch"]; exists {
+				if _, exists := pod.Labels["ecs.takutakahashi.dev/watch"]; exists {
 					logf.Log.Info("Pod with watch label created", "namespace", pod.Namespace, "name", pod.Name)
 					return true
 				}
@@ -72,7 +72,7 @@ func (r *PodWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if pod, ok := e.ObjectNew.(*corev1.Pod); ok {
-				if _, exists := pod.Labels["example.com/watch"]; exists {
+				if _, exists := pod.Labels["ecs.takutakahashi.dev/watch"]; exists {
 					return true
 				}
 			}
@@ -80,7 +80,7 @@ func (r *PodWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			if pod, ok := e.Object.(*corev1.Pod); ok {
-				if _, exists := pod.Labels["example.com/watch"]; exists {
+				if _, exists := pod.Labels["ecs.takutakahashi.dev/watch"]; exists {
 					logf.Log.Info("Pod with watch label deleted", "namespace", pod.Namespace, "name", pod.Name)
 					return true
 				}

--- a/internal/controller/podwatcher_controller_test.go
+++ b/internal/controller/podwatcher_controller_test.go
@@ -34,7 +34,7 @@ var _ = Describe("PodWatcher Controller", func() {
 	Context("When reconciling Pods with watch label", func() {
 		ctx := context.Background()
 
-		It("should reconcile Pod with example.com/watch label", func() {
+		It("should reconcile Pod with ecs.takutakahashi.dev/watch label", func() {
 			podName := "test-pod-with-label"
 			namespace := defaultNamespace
 
@@ -43,7 +43,7 @@ var _ = Describe("PodWatcher Controller", func() {
 					Name:      podName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						"example.com/watch": "true",
+						"ecs.takutakahashi.dev/watch": "true",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -66,7 +66,7 @@ var _ = Describe("PodWatcher Controller", func() {
 				return err == nil
 			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
 
-			Expect(createdPod.Labels["example.com/watch"]).Should(Equal("true"))
+			Expect(createdPod.Labels["ecs.takutakahashi.dev/watch"]).Should(Equal("true"))
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: podLookupKey,
@@ -113,7 +113,7 @@ var _ = Describe("PodWatcher Controller", func() {
 				return err == nil
 			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
 
-			Expect(createdPod.Labels["example.com/watch"]).Should(BeEmpty())
+			Expect(createdPod.Labels["ecs.takutakahashi.dev/watch"]).Should(BeEmpty())
 
 			Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
 		})
@@ -127,7 +127,7 @@ var _ = Describe("PodWatcher Controller", func() {
 					Name:      podName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						"example.com/watch": "true",
+						"ecs.takutakahashi.dev/watch": "true",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -62,9 +62,9 @@ func (d *PodCustomDefaulter) Default(_ context.Context, obj runtime.Object) erro
 	}
 
 	// Check if Pod has the watch label - if so, block its creation
-	if _, hasWatchLabel := pod.Labels["example.com/watch"]; hasWatchLabel {
+	if _, hasWatchLabel := pod.Labels["ecs.takutakahashi.dev/watch"]; hasWatchLabel {
 		podlog.Info("Blocking Pod creation due to watch label", "name", pod.GetName(), "namespace", pod.GetNamespace())
-		return fmt.Errorf("pod creation blocked: pods with label 'example.com/watch' are not allowed")
+		return fmt.Errorf("pod creation blocked: pods with label 'ecs.takutakahashi.dev/watch' are not allowed")
 	}
 
 	return nil

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Pod Webhook", func() {
 					Name:      "test-pod",
 					Namespace: "default",
 					Labels: map[string]string{
-						"example.com/watch": "true",
+						"ecs.takutakahashi.dev/watch": "true",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -73,7 +73,7 @@ var _ = Describe("Pod Webhook", func() {
 
 			By("checking that the Pod creation is blocked")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("pods with label 'example.com/watch' are not allowed"))
+			Expect(err.Error()).To(ContainSubstring("pods with label 'ecs.takutakahashi.dev/watch' are not allowed"))
 		})
 
 		It("Should also block Pod with watch label and additional annotations", func() {
@@ -83,8 +83,8 @@ var _ = Describe("Pod Webhook", func() {
 					Name:      "blocked-pod",
 					Namespace: "default",
 					Labels: map[string]string{
-						"example.com/watch": "true",
-						"app":               "test",
+						"ecs.takutakahashi.dev/watch": "true",
+						"app":                         "test",
 					},
 					Annotations: map[string]string{
 						"some-annotation": "value",
@@ -105,7 +105,7 @@ var _ = Describe("Pod Webhook", func() {
 
 			By("checking that the Pod creation is blocked")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("pods with label 'example.com/watch' are not allowed"))
+			Expect(err.Error()).To(ContainSubstring("pods with label 'ecs.takutakahashi.dev/watch' are not allowed"))
 		})
 
 		It("Should ignore Pod without watch label", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/example/pod-controller/test/utils"
+	"github.com/takutakahashi/k8s-ecstask/test/utils"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
-	projectImage = "example.com/pod-controller:v0.0.1"
+	projectImage = "ecs.takutakahashi.dev/pod-controller:v0.0.1"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/example/pod-controller/test/utils"
+	"github.com/takutakahashi/k8s-ecstask/test/utils"
 )
 
 // namespace where the project is deployed in


### PR DESCRIPTION
## Summary
- APIドメインを `example.com` から `ecs.takutakahashi.dev` に変更
- go moduleを `github.com/example/pod-controller` から `github.com/takutakahashi/k8s-ecstask` に変更
- 全ての関連ファイル（コード、テスト、設定ファイル）を更新

## Test plan
- [x] go mod tidy 実行済み
- [x] ビルド確認済み
- [x] 全インポートパス更新済み

🤖 Generated with [Claude Code](https://claude.ai/code)